### PR TITLE
libs: binder: MemoryHeapIon: ifdef ION_EXYNOS_VIDEO_MASK

### DIFF
--- a/libs/binder/MemoryHeapIon.cpp
+++ b/libs/binder/MemoryHeapIon.cpp
@@ -84,8 +84,10 @@ uint32_t ion_FlagMask_valid_check(uint32_t flags)
         result |= ION_FLAG_CACHED_NEEDS_SYNC;
     if (flag_mask & MHB_ION_FLAG_PRESERVE_KMAP)
         result |= ION_FLAG_PRESERVE_KMAP;
+#ifdef ION_EXYNOS_VIDEO_MASK
     if (flag_mask & MHB_ION_EXYNOS_VIDEO_MASK)
         result |= ION_EXYNOS_VIDEO_MASK;
+#endif
     if (flag_mask & MHB_ION_EXYNOS_MFC_INPUT_MASK)
         result |= ION_EXYNOS_MFC_INPUT_MASK;
     if (flag_mask & MHB_ION_EXYNOS_MFC_OUTPUT_MASK)


### PR DESCRIPTION
Exynos secure memory regions were separated here:
https://android.googlesource.com/platform/hardware/samsung_slsi/exynos5/+/ce73ba1%5E!/

Only compile the legacy ION_EXYNOS_VIDEO_MASK code if legacy HALs are used
(and ION_EXYNOS_VIDEO_MASK is defined).

Change-Id: I8cb58bbbb829d64a2ed39dbd27cc0d0ae3c9dd09
